### PR TITLE
fix import_module to support django 1.9 and greater

### DIFF
--- a/django_statsd/clients/__init__.py
+++ b/django_statsd/clients/__init__.py
@@ -1,6 +1,10 @@
 import socket
 
-from django.utils.importlib import import_module
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
+
 from django.conf import settings
 
 _statsd = None

--- a/django_statsd/patches/__init__.py
+++ b/django_statsd/patches/__init__.py
@@ -1,5 +1,9 @@
+try:
+    from django.utils.importlib import import_module
+except ImportError:
+    from importlib import import_module
+
 from django.conf import settings
-from django.utils.importlib import import_module
 
 patches = getattr(settings, 'STATSD_PATCHES', [])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mock
 nose
 statsd==2.1.2
+importlib==1.0.3
 django<1.7


### PR DESCRIPTION
Django 1.9 has removed `django.utils.importlib` library. It was deprecated in django 1.7 onwards. To support `scout_statsd_django` on `django 1.9` or greater we need stop depending on this library. 

In this PR I have removed this dependency by using python's library `importlib`. Importlib exposes the same `import_module` function. 
